### PR TITLE
Make version codes 64-bit

### DIFF
--- a/accrescent/server/events/v1/package_metadata.proto
+++ b/accrescent/server/events/v1/package_metadata.proto
@@ -16,9 +16,9 @@ option java_package = "app.accrescent.server.events.v1";
 // Metadata for a specific version of an Android package.
 message PackageMetadata {
   // The version code of the app's latest version.
-  optional uint32 version_code = 1 [
+  optional uint64 version_code = 1 [
     (buf.validate.field).required = true,
-    (buf.validate.field).uint32.gt = 0
+    (buf.validate.field).uint64.gt = 0
   ];
 
   // The display name of the app's latest version, e.g., "1.4.2".


### PR DESCRIPTION
Version codes on Android have traditionally been represented as 32-bit integers. However, since API 28 (Android 9), a versionCodeMajor attribute is available which extends the version code my another 32 bits, making it effectively a 64-bit integer. This fact is represented in the Android platform's `PackageInfo.versionCode` property being deprecated since Android 9 in favor of
`PackageInfo.getLongVersionCode()`.

Therefore, we should represent applications' canonical version codes as 64-bit integers to ensure we can accept all valid version codes including those incorporating versionCodeMajor.

References:

https://developer.android.com/reference/android/R.styleable#AndroidManifest_versionCodeMajor https://developer.android.com/reference/android/content/pm/PackageInfo#versionCode https://developer.android.com/reference/android/content/pm/PackageInfo#getLongVersionCode()